### PR TITLE
Hide admin chat instead of leaving it so we only create one per player max

### DIFF
--- a/web/src/bridge/bridge.js
+++ b/web/src/bridge/bridge.js
@@ -389,6 +389,13 @@ class FakeIdGenerator extends IdGenerator {
     playerId: 'PlayerId',
     timestamp: 'Timestamp',
   });
+  serverMethods.set('updateChatRoomMembership', {
+    gameId: 'GameId',
+    serverTime: '|Timestamp',
+    chatRoomId: 'ChatRoomId',
+    actingPlayerId: 'PlayerId',
+    visible: '|Boolean',
+  });
 
   serverMethods.set('createMap', {
     gameId: 'GameId',

--- a/web/src/bridge/fake/fakeserver.js
+++ b/web/src/bridge/fake/fakeserver.js
@@ -224,7 +224,7 @@ class FakeServer {
     this.writer.insert(
         this.reader.getPlayerChatRoomMembershipPath(gameId, playerId, null),
         null,
-        new Model.PlayerChatRoomMembership(chatRoomId, {chatRoomId: chatRoomId}));
+        new Model.PlayerChatRoomMembership(chatRoomId, {chatRoomId: chatRoomId, visible: true}));
   }
 
   addPlayerToMission_(gameId, missionId, playerId) {
@@ -271,6 +271,22 @@ class FakeServer {
           })));
     } else {
       throw 'Can\'t send message to chat room without membership';
+    }
+  }
+
+  updateChatRoomMembership(args) {
+    let {chatRoomId, actingPlayerId} = args;
+    let playerId = actingPlayerId;
+    let gameId = this.reader.getGameIdForPlayerId(playerId);
+    let game = this.database.gamesById[gameId];
+    let player = game.playersById[playerId];
+
+    let playerChatRoomMembershipPath = this.reader.getPlayerChatRoomMembershipPath(gameId, playerId, chatRoomId);
+
+    for (let argName in args) {
+      this.writer.set(
+          playerChatRoomMembershipPath.concat([argName]),
+          args[argName]);
     }
   }
 

--- a/web/src/bridge/model.js
+++ b/web/src/bridge/model.js
@@ -92,7 +92,7 @@ Model.GroupMembership = function(id, args) {
   Utils.addEmptyLists(this, GROUP_MEMBERSHIP_COLLECTIONS);
 }
 
-const PLAYER_CHAT_ROOM_MEMBERSHIP_PROPERTIES = ["chatRoomId"];
+const PLAYER_CHAT_ROOM_MEMBERSHIP_PROPERTIES = ["chatRoomId", "visible"];
 const PLAYER_CHAT_ROOM_MEMBERSHIP_COLLECTIONS = [];
 Model.PlayerChatRoomMembership = function(id, args) {
   this.id = id;

--- a/web/src/chat/chat-info-actions.html
+++ b/web/src/chat/chat-info-actions.html
@@ -78,7 +78,11 @@
         },
 
         leaveChat_: function() {
-          this.$.leaveForm.open();
+          if (this.chatRoom.withAdmins) {
+            this.hideChat_();
+          } else {
+            this.$.leaveForm.open();
+          }
         },
 
         onConfirmLeave_: function(e) {
@@ -87,6 +91,20 @@
             groupId: this.chatRoom.accessGroupId,
             actingPlayerId: this.playerId,
             playerToRemoveId: this.playerId,
+          });
+        },
+
+        hideChat_: function() {
+          this.bridge.updateChatRoomMembership({
+            gameId: this.game.id, 
+            chatRoomId: this.chatRoom.id,
+            actingPlayerId: this.playerId,
+            visible: false,
+          });
+          this.fire('ghvz-set-path', {
+            inGame: true,
+            path: ['chat'],
+            replace: true,
           });
         },
 

--- a/web/src/chat/chat-info-actions.html
+++ b/web/src/chat/chat-info-actions.html
@@ -101,11 +101,13 @@
             actingPlayerId: this.playerId,
             visible: false,
           });
-          this.fire('ghvz-set-path', {
-            inGame: true,
-            path: ['chat'],
-            replace: true,
-          });
+          if (this.isAdmin) {
+            this.fire('ghvz-set-path', {
+              inGame: true,
+              path: ['chat'],
+              replace: true,
+            });
+          }
         },
 
         kickFromChat_: function(playerId, game) {

--- a/web/src/chat/chat-info-actions.html
+++ b/web/src/chat/chat-info-actions.html
@@ -101,6 +101,8 @@
             actingPlayerId: this.playerId,
             visible: false,
           });
+          // We don't acutally hide the admin chat since admins might want access to it later.
+          // Instead just navigate to the main chat page to make it appear like we hide the chat
           if (this.isAdmin) {
             this.fire('ghvz-set-path', {
               inGame: true,

--- a/web/src/chat/chat-info-drawer.html
+++ b/web/src/chat/chat-info-drawer.html
@@ -59,7 +59,7 @@
 
           showPlayerDropdown: {
             type: Boolean,
-            computed: 'computeShowPlayerDropdown_(canRemove)',
+            computed: 'computeShowPlayerDropdown_(canRemoveOthers)',
           },
         },
 

--- a/web/src/chat/chat-page.html
+++ b/web/src/chat/chat-page.html
@@ -71,14 +71,15 @@
           if (chatRoomId) {
             this.$.chatRoomSelector.select(
                 this.game.chatRooms.find(chatRoom => {
-                 /* let visible;
+                  let visible;
                   let memberSetting = this.player.chatRoomMembershipsById[chatRoomId];
-                  if (!memberSetting && this.isAdmin) {
-                    visible = true;
-                  } else if (memberSetting) {
+                  if (memberSetting) {
                     visible = memberSetting.visible;
-                  } */
-                  return chatRoom.id == chatRoomId;
+                  }
+                  if (this.isAdmin) {
+                    visible = true;
+                  }
+                  return chatRoom.id == chatRoomId && visible;
                 }));
             if (this.$.chatRoomSelector.selected != null) {
               return;

--- a/web/src/chat/chat-page.html
+++ b/web/src/chat/chat-page.html
@@ -70,7 +70,16 @@
           var chatRoomId = this.path[1];
           if (chatRoomId) {
             this.$.chatRoomSelector.select(
-                this.game.chatRooms.find(chatRoom => chatRoom.id == chatRoomId));
+                this.game.chatRooms.find(chatRoom => {
+                 /* let visible;
+                  let memberSetting = this.player.chatRoomMembershipsById[chatRoomId];
+                  if (!memberSetting && this.isAdmin) {
+                    visible = true;
+                  } else if (memberSetting) {
+                    visible = memberSetting.visible;
+                  } */
+                  return chatRoom.id == chatRoomId;
+                }));
             if (this.$.chatRoomSelector.selected != null) {
               return;
             }

--- a/web/src/chat/chat-room-list.html
+++ b/web/src/chat/chat-room-list.html
@@ -15,11 +15,14 @@
 
           adminChatExists: Boolean,
 
+          adminChatRoomId: String,
+
           waitingToOpenChatRoomId: String,
         },
 
         observers: [
-          'onChatRoomsUpdated_(game, player.chatRoomMemberships.length)',
+          'onChatRoomsUpdated_(game, player.chatRoomMemberships.*)',
+          //'onChatRoomMembershipsChanged_(currentPlayer.chatRoomMemberships.*)',
         ],
         
         listeners: {
@@ -40,8 +43,11 @@
             let chatRoomId = chatRoomMembership.chatRoomId;
             let chatRoom = this.game.chatRoomsById[chatRoomId];
             if (chatRoom.withAdmins) {
-              this.adminChatExists = true;
-              return;
+              this.adminChatRoomId = chatRoomId;
+              if (chatRoomMembership.visible) {
+                this.adminChatExists = true;
+                return;
+              }
             }
           }
           this.adminChatExists = false;
@@ -84,6 +90,20 @@
         },
 
         createAdminChat_() {
+          if (this.adminChatRoomId) {
+            for (let chatRoomMembership of this.player.chatRoomMemberships) {
+              if (chatRoomMembership.chatRoomId == this.adminChatRoomId) {
+                this.waitingToOpenChatRoomId = chatRoomMembership.chatRoomId;
+                this.bridge.updateChatRoomMembership({
+                  gameId: this.game.id, 
+                  chatRoomId: chatRoomMembership.chatRoomId,
+                  actingPlayerId: this.player.id,
+                  visible: true,
+                });
+                return;
+              }
+            }
+          }
           let name =  this.player.name + " & HvZ CDC";
           let groupId = this.bridge.newGroupId('withadmins');
           this.bridge.createGroup({
@@ -192,15 +212,17 @@
   <template>
     <div class="frame" on-tap="captureTap_">
       <template is="dom-repeat" items="[[player.chatRoomMemberships]]" as="membership">
-        <ghvz-chat-room-name-label
-            name$="[[membership.chatRoomId]]"
-            class="layout horizontal list-item name-label"
-            with-icon
-            game="[[game]]"
-            name$="[[getChatRoomName_(membership.chatRoomId)]]"
-            chat-room-id="[[membership.chatRoomId]]"
-            data-chat-room-id$="[[membership.chatRoomId]]">
-        </ghvz-chat-room-name-label>
+        <template is="dom-if" if="[[membership.visible]]">
+          <ghvz-chat-room-name-label
+              name$="[[membership.chatRoomId]]"
+              class="layout horizontal list-item name-label"
+              with-icon
+              game="[[game]]"
+              name$="[[getChatRoomName_(membership.chatRoomId)]]"
+              chat-room-id="[[membership.chatRoomId]]"
+              data-chat-room-id$="[[membership.chatRoomId]]">
+          </ghvz-chat-room-name-label>
+        </template>
       </template>
     </div>
 

--- a/web/src/chat/chat-room-list.html
+++ b/web/src/chat/chat-room-list.html
@@ -22,7 +22,6 @@
 
         observers: [
           'onChatRoomsUpdated_(game, player.chatRoomMemberships.*)',
-          //'onChatRoomMembershipsChanged_(currentPlayer.chatRoomMemberships.*)',
         ],
         
         listeners: {

--- a/web/src/chat/chat-room.html
+++ b/web/src/chat/chat-room.html
@@ -52,7 +52,6 @@
           'onChatRoomIdChange_(chatRoomId, game.chatRooms, game.chatRoomsById)',
           'onChatRoomNameChange_(chatRoom.name, isAttached)',
           'onMessageReceived_(chatRoom.messages.length)',
-          'onChatRoomMembershipsChanged_(currentPlayer.chatRoomMemberships.*)',
         ],
 
         locationEnabled(isMobile) {
@@ -77,9 +76,6 @@
 
         onChatRoomNameChange_: function() {
           this.fire('ghvz-set-card-header-text', { headerText: this.chatRoom.name });
-        },
-
-        onChatRoomMembershipsChanged_() {
         },
 
         onMessageReceived_() {

--- a/web/src/chat/chat-room.html
+++ b/web/src/chat/chat-room.html
@@ -581,6 +581,7 @@
       bridge="[[bridge]]"
       game="[[game]]"
       player-id="[[currentPlayer.id]]"
+      is-admin="[[isAdmin]]"
       chat-room="[[chatRoom]]">
     </ghvz-chat-info-actions>
   </template>

--- a/web/src/chat/chat-room.html
+++ b/web/src/chat/chat-room.html
@@ -40,6 +40,8 @@
             type: Boolean,
             value: false,
           },
+
+          
         },
 
         listeners: {
@@ -50,6 +52,7 @@
           'onChatRoomIdChange_(chatRoomId, game.chatRooms, game.chatRoomsById)',
           'onChatRoomNameChange_(chatRoom.name, isAttached)',
           'onMessageReceived_(chatRoom.messages.length)',
+          'onChatRoomMembershipsChanged_(currentPlayer.chatRoomMemberships.*)',
         ],
 
         locationEnabled(isMobile) {
@@ -74,6 +77,9 @@
 
         onChatRoomNameChange_: function() {
           this.fire('ghvz-set-card-header-text', { headerText: this.chatRoom.name });
+        },
+
+        onChatRoomMembershipsChanged_() {
         },
 
         onMessageReceived_() {

--- a/web/src/drawer/drawer.html
+++ b/web/src/drawer/drawer.html
@@ -260,15 +260,17 @@
         </template>
         <template is="dom-if" if="[[!isAdmin]]">
           <template is="dom-repeat" items="[[player.chatRoomMemberships]]" as="membership">
-            <ghvz-chat-room-name-label
-                class="layout horizontal listing drawer-item"
-                with-icon
-                name$="drawer-[[getChatName_(membership.chatRoomId)]]"
-                game="[[game]]"
-                chat-room-id="[[membership.chatRoomId]]"
-                data-page="chat"
-                data-chat-room-id$="[[membership.chatRoomId]]">
-            </ghvz-chat-room-name-label>
+            <template is="dom-if" if="[[membership.visible]]">
+              <ghvz-chat-room-name-label
+                  class="layout horizontal listing drawer-item"
+                  with-icon
+                  name$="drawer-[[getChatName_(membership.chatRoomId)]]"
+                  game="[[game]]"
+                  chat-room-id="[[membership.chatRoomId]]"
+                  data-page="chat"
+                  data-chat-room-id$="[[membership.chatRoomId]]">
+              </ghvz-chat-room-name-label>
+            </template>
           </template>
         </template>
       </div>

--- a/web/src/main/desktop-main.html
+++ b/web/src/main/desktop-main.html
@@ -199,16 +199,18 @@
         </template>
 
         <template is="dom-repeat" items="[[player.chatRoomMemberships]]" as="membership">
-          <ghvz-card spaced left name$="[[membership.chatRoomId]]">
-            <ghvz-chat-room
-                small
-                bridge="[[bridge]]"
-                game="[[game]]"
-                is-admin="[[isAdmin]]"
-                current-player="[[player]]"
-                chat-room-id="[[membership.chatRoomId]]">
-            </ghvz-chat-room>
-          </ghvz-card>
+          <template is="dom-if" if="[[membership.visible]]">
+            <ghvz-card spaced left name$="[[membership.chatRoomId]]">
+              <ghvz-chat-room
+                  small
+                  bridge="[[bridge]]"
+                  game="[[game]]"
+                  is-admin="[[isAdmin]]"
+                  current-player="[[player]]"
+                  chat-room-id="[[membership.chatRoomId]]">
+              </ghvz-chat-room>
+            </ghvz-card>
+          </template>
         </template>
       </template>
 

--- a/web/tests/adminchat.py
+++ b/web/tests/adminchat.py
@@ -1,99 +1,94 @@
 import setup
 from selenium.webdriver.common.by import By
 
+## Test setup
+playerNames = {
+  'zella': 'ZellaTheUltimate',
+  'deckerd': 'DeckerdTheHesitant',
+  'moldavi': 'MoldaviTheMoldavish',
+  'drake': 'Drackan',
+  'zeke': 'Zeke',
+  'jack': 'JackSlayerTheBeanSlasher'
+}
+
+adminPlayers = ['zella', 'moldavi']
+
+def getPathToElement(playerName, tag, name):
+  xpathForPageElement = "//*[contains(@id, 'chat-page-%s')]//%s[contains(@name, '%s')]"
+  return xpathForPageElement % (playerName, tag, name)
+
+def changeToPage(driver, drawerOption):
+  driver.Click([[By.NAME, 'drawer' + drawerOption]])
+
+def closeNotifications(driver):
+    driver.Click([[By.NAME, 'close-notification']])
+
+
+
+## Run admin chat test
 driver = setup.MakeDriver()
 driver.WaitForGameLoaded()
 
-try:
-  playerNames = {
-        'zella': 'ZellaTheUltimate',
-        'deckerd': 'DeckerdTheHesitant',
-        'moldavi': 'MoldaviTheMoldavish',
-        'drake': 'Drackan',
-        'zeke': 'Zeke',
-        'jack': 'JackSlayerTheBeanSlasher'
-      }
+actingPlayer = 'zeke'
+actingPlayerName = playerNames[actingPlayer]
+chatName = actingPlayerName + ' & HvZ CDC'
 
-  adminPlayers = ['zella', 'moldavi']
+# Switch to right user and open chat page
+driver.SwitchUser(actingPlayer)
+changeToPage(driver, 'Chat')
 
-  def getPathToElement(playerName, tag, name):
-    xpathForPageElement = "//*[contains(@id, 'chat-page-%s')]//%s[contains(@name, '%s')]"
-    return xpathForPageElement % (playerName, tag, name)
+# Create chat with admin
+driver.FindElement([[By.NAME, 'create-admin-chat-button']])
+driver.Click([[By.NAME, 'create-admin-chat-button']]) 
+driver.FindElement([[By.NAME, chatName]])  
+driver.DontFindElement([[By.NAME, 'create-admin-chat-button']])
 
-  def changeToPage(driver, drawerOption):
-    driver.Click([[By.NAME, 'drawer' + drawerOption]])
+# Type a message into the chat
+xpathTextarea = getPathToElement(actingPlayerName, 'textarea', 'input-' + chatName)
+xpathSend = getPathToElement(actingPlayerName, 'paper-button', 'submit-' + chatName)
 
-  def closeNotifications(driver):
-    try: 
-      driver.Click([[By.NAME, 'close-notification']])
-    finally:
-      pass
-  
-  def testAdminChat(actingPlayer, adminPlayers):
-    try: 
-      actingPlayerName = playerNames[actingPlayer]
-      chatName = actingPlayerName + ' & HvZ CDC'
+driver.FindElement([[By.NAME, 'input-%s' % chatName], [By.XPATH, xpathTextarea]]) 
+driver.SendKeys([[By.NAME, 'input-%s' % chatName], [By.XPATH, xpathTextarea]], 
+  'Hi im %s, how do i know if im the possessed zombie?' % actingPlayerName)
+driver.Click([[By.NAME, 'submit-%s' % chatName], [By.XPATH, xpathSend]])
 
-      # Create chat with admin
-      driver.SwitchUser(actingPlayer)
+# Check that every admin sees the chat and message
+for admin in adminPlayers:
+  driver.SwitchUser(admin)
+  closeNotifications(driver)
+  driver.FindElement([[By.NAME, 'drawer-' + chatName]])  
+  changeToPage(driver, '-' + chatName)
+  driver.ExpectContains([
+      [By.NAME, 'chat-card'], 
+      [By.NAME, 'message-%s-Hi im %s, how do i know if im the possessed zombie?' % (chatName, actingPlayerName)], 
+      [By.CLASS_NAME, 'message-text']], 
+      'Hi im %s, how do i know if im the possessed zombie?' % actingPlayerName)
 
-      changeToPage(driver, 'Chat')
+# Non-Admin should leave admin chat
+driver.SwitchUser(actingPlayer)
+changeToPage(driver, '-' + chatName)
 
-      driver.FindElement([[By.NAME, 'create-admin-chat-button']])
-      driver.Click([[By.NAME, 'create-admin-chat-button']]) 
-      driver.FindElement([[By.NAME, chatName]])  
-      driver.DontFindElement([[By.NAME, 'create-admin-chat-button']])
+xpathChatDrawerButton = getPathToElement(actingPlayerName, 'paper-icon-button', 'chat-info-' + chatName)
+driver.Click([[By.XPATH, xpathChatDrawerButton]])  
+xpathChatDrawer = getPathToElement(actingPlayerName, 'div', 'chat-drawer-%s' % chatName)
+driver.FindElement([[By.XPATH, xpathChatDrawer]])  
+#driver.FindElement([[By.NAME, 'chat-card'], [By.NAME, 'chat-drawer-%s' % chatName]])
 
-      # Type a message into the chat
-      xpathTextarea = getPathToElement(actingPlayerName, 'textarea', 'input-' + chatName)
-      xpathSend = getPathToElement(actingPlayerName, 'paper-button', 'submit-' + chatName)
-      
-      driver.FindElement([[By.NAME, 'input-%s' % chatName], [By.XPATH, xpathTextarea]]) 
-      driver.SendKeys([[By.NAME, 'input-%s' % chatName], [By.XPATH, xpathTextarea]], 
-        'Hi im %s, how do i know if im the possessed zombie?' % actingPlayerName)
-      driver.Click([[By.NAME, 'submit-%s' % chatName], [By.XPATH, xpathSend]])
+xpathLeaveButton = getPathToElement(actingPlayerName, 'a', 'chat-drawer-leave')
+driver.FindElement([[By.XPATH, xpathLeaveButton]])
+driver.Click([[By.XPATH, xpathLeaveButton]])
 
-      # Check that every admin sees the chat and message
-      for admin in adminPlayers:
-        driver.SwitchUser(admin)
-        closeNotifications(driver)
-        driver.FindElement([[By.NAME, 'drawer-' + chatName]])  
-        changeToPage(driver, '-' + chatName)
-        driver.ExpectContains([
-            [By.NAME, 'chat-card'], 
-            [By.NAME, 'message-%s-Hi im %s, how do i know if im the possessed zombie?' % (chatName, actingPlayerName)], 
-            [By.CLASS_NAME, 'message-text']], 
-            'Hi im %s, how do i know if im the possessed zombie?' % actingPlayerName)
+# Chat should be hidden, verify chat with admin button is available after leaving admin chat
+driver.FindElement([[By.NAME, 'create-admin-chat-button']])
 
-      # Non-Admin should leave admin chat
-      driver.SwitchUser(actingPlayer)
-      changeToPage(driver, '-' + chatName)
+# Reopen admin chat
+driver.Click([[By.NAME, 'create-admin-chat-button']]) 
 
-      xpathChatDrawerButton = getPathToElement(actingPlayerName, 'paper-icon-button', 'chat-info-' + chatName)
-      driver.Click([[By.XPATH, xpathChatDrawerButton]])  
-      xpathChatDrawer = getPathToElement(actingPlayerName, 'div', 'chat-drawer-%s' % chatName)
-      driver.FindElement([[By.XPATH, xpathChatDrawer]])  
-      #driver.FindElement([[By.NAME, 'chat-card'], [By.NAME, 'chat-drawer-%s' % chatName]])
-      
-      xpathLeaveButton = getPathToElement(actingPlayerName, 'a', 'chat-drawer-leave')
-      driver.FindElement([[By.XPATH, xpathLeaveButton]])
-      driver.Click([[By.XPATH, xpathLeaveButton]])
+# Verify original message is still in chat room
+driver.ExpectContains([
+  [By.NAME, 'chat-card'], 
+  [By.NAME, 'message-%s-Hi im %s, how do i know if im the possessed zombie?' % (chatName, actingPlayerName)], 
+  [By.CLASS_NAME, 'message-text']], 
+  'Hi im %s, how do i know if im the possessed zombie?' % actingPlayerName)
 
-      xpathLeaveDialog = getPathToElement(actingPlayerName, '*', 'chat-leave-dialog-' + chatName)
-      driver.FindElement([[By.XPATH, xpathLeaveDialog]])
-      driver.Click([[By.XPATH, xpathLeaveDialog], [By.ID, 'done']])
-      driver.DontFindElement([[By.XPATH, xpathLeaveDialog]])
-      
-      # Verify chat with admin button is available after leaving admin chat
-      driver.FindElement([[By.NAME, 'create-admin-chat-button']])
-      
-    finally:
-      pass
-
-  # Run admin chat tests 
-  testAdminChat('zeke', adminPlayers)
-
-  driver.Quit()
-
-finally:
-  pass
+driver.Quit()

--- a/web/tests/chatpage.py
+++ b/web/tests/chatpage.py
@@ -96,4 +96,15 @@ driver.Click([[By.ID, 'chat-page-' + actingPlayerName], [By.ID, 'kickForm'], [By
 # Confirm player was kicked
 driver.DontFindElement([[By.TAG_NAME, 'ghvz-chat-page'], [By.NAME, playerNames['drake']]])
 
+# Leave the chat
+xpathLeaveButton = getPathToElement(actingPlayerName, 'a', 'chat-drawer-leave')
+driver.FindElement([[By.XPATH, xpathLeaveButton]])
+driver.Click([[By.XPATH, xpathLeaveButton]])
+
+xpathLeaveDialog = getPathToElement(actingPlayerName, '*', 'chat-leave-dialog-' + newChatName)
+driver.FindElement([[By.XPATH, xpathLeaveDialog]])
+driver.Click([[By.XPATH, xpathLeaveDialog], [By.ID, 'done']])
+driver.DontFindElement([[By.XPATH, xpathLeaveDialog]])
+driver.DontFindElement([[By.ID, 'chat-page-%s' % actingPlayerName], [By.NAME, newChatName]])
+      
 driver.Quit()


### PR DESCRIPTION
adminchat.py should fail on remote but pass on fake. should pass on remote when model is updated with 'visible' field in chatroommembership

alternative names to 'visible': 'hidden' or 'isVisible', thoughts?