### PR TITLE
notifications: Replace regular notifications with a data only notification

### DIFF
--- a/backend/notifications.py
+++ b/backend/notifications.py
@@ -50,8 +50,7 @@ def HandleNotification(game_state, queued_notification_id, queued_notification):
     return
   if config.FIREBASE_APIKEY:
     fcm.notify_multiple_devices(registration_ids=list(device_tokens),
-                                message_title=notification['previewMessage'],
-                                message_body=notification['message'])
+                                data_message=notification)
 
 def ExecuteNotifications(request, game_state):
   """INTERNAL ONLY: Send the notifications.


### PR DESCRIPTION
This will allow the app the handle the message directly and control the
nature of the notification itself.